### PR TITLE
Resolve Python 3.12.x Build Errors by Updating Dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.11.5-slim-bookworm
+FROM python:3.12.1-slim-bookworm
 
 ARG S6_OVERLAY_VERSION=3.1.6.2 LAVALINK_VERSION=4.0.0 DEBIAN_FRONTEND="noninteractive"
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-lavalink==5.1.0
 PyNaCl==1.5.0
 spotipy==2.23.0
 requests==2.31.0
@@ -10,4 +9,5 @@ yt-dlp==2023.12.30
 colorlog
 youtube-related
 youtube-search
+git+https://github.com/Nat1anWasTaken/Lavalink.py.git
 git+https://github.com/Snipy7374/disnake-ext-paginator.git


### PR DESCRIPTION
This pull request addresses the build errors encountered when upgrading the project to Python version 3.12.x. The issue was initially reported under the project's GitHub issues, noting that updating the Python image tag from `3.11.5-slim-bookworm` to `3.12.1-slim-bookworm` resulted in building errors.

**Key Changes:**
- Updated the Dockerfile base image to `python:3.12.1-slim-bookworm`. This ensures compatibility with the latest version of Python, facilitating the use of new features and improvements introduced in Python 3.12.x.
- Modified `requirements.txt` to update project dependencies. This step was crucial in resolving compatibility issues between the new Python version and the existing dependencies, which contributed to the building errors.

These changes were encapsulated in the following commits:
- 9348e89 (HEAD -> 88-bug-python-3-12, origin/88-bug-python-3-12) 🔄 chore(Dockerfile): update base image to `python:3.12.1-slim-bookworm` to use the latest version of Python.
- 1bcad51 📦 chore(requirements.txt): update dependencies.

By merging this pull request, we ensure that the project is up-to-date with the latest Python version, enhancing its stability and performance while maintaining compatibility with project dependencies.