### PR TITLE
ci: fix docker bake problem with GitHub action

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -26,11 +26,6 @@ jobs:
 
       # Build and push Docker image
       - name: Build and push
-        uses: docker/build-push-action@v5
+        uses: docker/bake-action@v4
         with:
-          context: .
-          file: ./Dockerfile
           push: true
-          tags: ghcr.io/nat1anwastaken/lava:latest
-          # Specify the platforms you want to build for
-          platforms: linux/amd64,linux/arm64,linux/arm/v7,linux/arm/v8

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -1,0 +1,36 @@
+group "default" {
+  targets = ["main", "amd64", "arm64", "armv7"]
+}
+
+function "getTag" {
+  params = [
+    tagName
+  ]
+  result = flatten([
+    "ghcr.io/nat1anwastaken/lava:${tagName}"
+  ])
+}
+
+target "main" {
+  platforms = ["linux/amd64", "linux/arm64", "linux/arm/v7"]
+  dockerfile = "./Dockerfile"
+  tags = getTag("latest")
+}
+
+target "amd64" {
+  inherits = ["main"]
+  platforms = ["linux/amd64"]
+  tags = getTag("amd64")
+}
+
+target "arm64" {
+  inherits = ["main"]
+  platforms = ["linux/arm64"]
+  tags = getTag("arm64")
+}
+
+target "armv7" {
+  inherits = ["main"]
+  platforms = ["linux/armv7"]
+  tags = getTag("armv7")
+}


### PR DESCRIPTION
What happened in the last PR: GitHub Action included `docker-compose.yml`, which shouldn't be included. `docker-compose.yml` could also be used for defining bake files.